### PR TITLE
Fix segfault at password verification

### DIFF
--- a/gllock.c
+++ b/gllock.c
@@ -28,6 +28,8 @@
 #include <string.h>
 #include <stdbool.h>
 
+#include <crypt.h>
+
 #include <GL/glew.h>
 #include <GL/glx.h>
 
@@ -149,7 +151,7 @@ readpw(const char* pws)
     {
       buf[0] = 0;
       num = XLookupString(&ev.xkey, buf, sizeof buf, &ksym, 0);
-      
+
       if(IsKeypadKey(ksym))
       {
         if(ksym == XK_KP_Enter)
@@ -286,7 +288,7 @@ animation_runner(void* arg)
 
 
 
-int 
+int
 lockscreen(lock_t* lock) {
   unsigned int len;
   Cursor invisible = 0;


### PR DESCRIPTION
This should fix issue #3 

The problem is that since the header <crypt.h> is not present, GCC misrepresents the return value of the call to crypt at line 174, hence the address problem once in strcmp.