### PR TITLE
Removed symlink to user's home directory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,7 @@ install: all
 	@cp -f gllock ${DESTDIR}${PREFIX}/bin
 	@chmod 755 ${DESTDIR}${PREFIX}/bin/gllock
 	@chmod u+s ${DESTDIR}${PREFIX}/bin/gllock
-	@ln -sr shaders ${SHADER_LOCATION}
-
+	@install -Dt ${DESTDIR}${SHADER_LOCATION} shaders/* 
 uninstall:
 	@echo removing executable file from ${DESTDIR}${PREFIX}/bin
 	@rm -f ${DESTDIR}${PREFIX}/bin/gllock

--- a/config.mk
+++ b/config.mk
@@ -4,7 +4,7 @@ VERSION = 0.1-alpha
 # Customize below to fit your system
 
 # paths
-SHADER_LOCATION = $(HOME)/.gllock
+SHADER_LOCATION = /usr/lib/gllock/shaders/
 
 # shader
 # FRGMNT_SHADER = blur.fragment.glsl
@@ -14,7 +14,7 @@ FRGMNT_SHADER = circle.fragment.glsl
 # FRGMNT_SHADER = ascii.fragment.glsl
 # FRGMNT_SHADER = crt.fragment.glsl
 
-PREFIX = /usr/local
+PREFIX = /usr
 
 X11INC = /usr/X11R6/include
 X11LIB = /usr/X11R6/lib


### PR DESCRIPTION
Just a thought, it might be better to avoid symbolic links in the default installation, especially symlinks to the compilation directory. Just a suggestion, as this would make packaging this software much simpler for downstream folks!

Humbly, 
Aaron